### PR TITLE
Weight bubbles by logged activity duration

### DIFF
--- a/App/AppState.swift
+++ b/App/AppState.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Combine
+
+@MainActor
+final class AppState: ObservableObject {
+    enum LogState: Equatable {
+        case idle
+        case running(since: Date)
+        case prompting
+    }
+
+    @Published private(set) var state: LogState = .idle
+    @Published var promptText: String = ""
+    @Published var isPromptPresented: Bool = false
+
+    @Published private(set) var availableActivities: [Activity] = []
+    @Published private(set) var runningSession: Session?
+    @Published private(set) var dayBuckets: [DayBucket] = []
+
+    private var store: Store
+    private var cancellables = Set<AnyCancellable>()
+
+    init(store: Store) {
+        self.store = store
+        bindStore()
+        resumeIfNeeded()
+    }
+
+    func startLogging(activityName: String?) {
+        guard runningSession == nil else { return }
+        store.startSession(named: activityName)
+        runningSession = store.runningSession
+        if let start = store.runningSession?.start {
+            state = .running(since: start)
+        } else {
+            state = .running(since: Date())
+        }
+        isPromptPresented = false
+        promptText = ""
+    }
+
+    func stopLogging() {
+        guard runningSession != nil else { return }
+        store.stopSession()
+        runningSession = store.runningSession
+        state = .prompting
+        promptText = runningSession?.activityName ?? ""
+        isPromptPresented = true
+    }
+
+    func resumeIfNeeded() {
+        guard let running = store.runningSession else { return }
+        runningSession = running
+        if running.end != nil {
+            state = .prompting
+            promptText = running.activityName
+            isPromptPresented = true
+        } else {
+            state = .running(since: running.start)
+        }
+    }
+
+    func confirmActivityName(_ name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        store.finalizeSession(activityName: trimmed)
+        runningSession = store.runningSession
+        isPromptPresented = false
+        state = .idle
+        promptText = ""
+    }
+
+    func selectExistingActivity(_ activity: Activity) {
+        promptText = activity.name
+        confirmActivityName(activity.name)
+    }
+
+    func totalSeconds(for activityName: String) -> Int {
+        store.totalSeconds(for: activityName)
+    }
+
+    private func bindStore() {
+        store.$activities
+            .receive(on: DispatchQueue.main)
+            .map { $0.sortedByRecent() }
+            .assign(to: &$availableActivities)
+
+        store.$runningSession
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] session in
+                guard let self else { return }
+                self.runningSession = session
+                if let session {
+                    if session.end != nil {
+                        if self.state != .prompting {
+                            self.state = .prompting
+                            self.promptText = session.activityName
+                            self.isPromptPresented = true
+                        }
+                        // Keep prompting state while awaiting confirmation.
+                        return
+                    }
+                    if self.state != .prompting {
+                        self.state = .running(since: session.start)
+                    }
+                } else if self.state != .prompting {
+                    self.state = .idle
+                }
+            }
+            .store(in: &cancellables)
+
+        store.$dayBuckets
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] buckets in
+                self?.dayBuckets = buckets
+            }
+            .store(in: &cancellables)
+    }
+}

--- a/App/NeologApp.swift
+++ b/App/NeologApp.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+@main
+struct NeologApp: App {
+    @StateObject private var store: Store
+    @StateObject private var appState: AppState
+
+    init() {
+        let store = Store()
+        _store = StateObject(wrappedValue: store)
+        _appState = StateObject(wrappedValue: AppState(store: store))
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            LoggingView()
+                .environmentObject(appState)
+        }
+    }
+}

--- a/Features/Bubbles/BubblePhysics.swift
+++ b/Features/Bubbles/BubblePhysics.swift
@@ -1,0 +1,141 @@
+import Foundation
+import SwiftUI
+import QuartzCore
+
+struct Bubble: Identifiable, Codable {
+    var id: UUID
+    var activityName: String
+    var colorHex: String
+    var position: CGPoint
+    var velocity: CGVector
+    var radius: CGFloat
+
+    init(id: UUID = UUID(), activityName: String, colorHex: String, position: CGPoint, velocity: CGVector, radius: CGFloat) {
+        self.id = id
+        self.activityName = activityName
+        self.colorHex = colorHex
+        self.position = position
+        self.velocity = velocity
+        self.radius = radius
+    }
+}
+
+final class BubblePhysics: ObservableObject {
+    @Published var bubbles: [Bubble] = []
+    private var displayLink: CADisplayLink?
+    private var bounds: CGSize = .zero
+    private var weightedActivities: [(activity: Activity, cumulativeWeight: Double)] = []
+    private var totalWeight: Double = 0
+
+    func configure(bounds: CGSize, activities: [Activity], running: Session?) {
+        self.bounds = bounds
+        var pool = activities
+        if let running, !running.activityName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           pool.first(where: { $0.name.caseInsensitiveCompare(running.activityName) == .orderedSame }) == nil {
+            let hex = colorHex(for: running.activityName)
+            let activity = Activity(name: running.activityName, colorHex: hex, totalSeconds: running.durationSeconds)
+            pool.append(activity)
+        }
+        guard !pool.isEmpty else {
+            bubbles.removeAll()
+            weightedActivities = []
+            totalWeight = 0
+            return
+        }
+        rebuildWeights(using: pool, running: running)
+
+        bubbles = bubbles.filter { bubble in
+            pool.contains { $0.name.caseInsensitiveCompare(bubble.activityName) == .orderedSame }
+        }
+
+        let baselineCount = pool.count * 8
+        let historyMinutes = max(totalWeight / 60.0, 1)
+        let densityCount = Int(sqrt(historyMinutes)) * 6
+        let targetCount = min(120, max(20, max(baselineCount, densityCount)))
+        if bubbles.count < targetCount {
+            let diff = targetCount - bubbles.count
+            let newBubbles = (0..<diff).compactMap { _ -> Bubble? in
+                guard let activity = pickWeightedActivity(fallbackPool: pool) else { return nil }
+                return makeBubble(for: activity)
+            }
+            bubbles.append(contentsOf: newBubbles)
+        } else if bubbles.count > targetCount {
+            bubbles = Array(bubbles.prefix(targetCount))
+        }
+
+        if let running,
+           let activity = pool.first(where: { $0.name.caseInsensitiveCompare(running.activityName) == .orderedSame }) {
+            bubbles.enumerated().forEach { idx, bubble in
+                if bubble.activityName.caseInsensitiveCompare(activity.name) == .orderedSame {
+                    bubbles[idx].radius = max(bubble.radius, 24)
+                } else {
+                    bubbles[idx].radius = max(14, bubble.radius * 0.95)
+                }
+            }
+        }
+
+        if displayLink == nil {
+            let link = CADisplayLink(target: self, selector: #selector(step))
+            link.add(to: .main, forMode: .common)
+            displayLink = link
+        }
+    }
+
+    func tearDown() {
+        displayLink?.invalidate()
+        displayLink = nil
+    }
+
+    @objc private func step(link: CADisplayLink) {
+        let delta = max(0.016, link.targetTimestamp - link.timestamp)
+        var updated = bubbles
+        for index in updated.indices {
+            var bubble = updated[index]
+            bubble.position.x += bubble.velocity.dx * delta
+            bubble.position.y += bubble.velocity.dy * delta
+
+            if bubble.position.x < -bubble.radius { bubble.position.x = bounds.width + bubble.radius }
+            if bubble.position.x > bounds.width + bubble.radius { bubble.position.x = -bubble.radius }
+            if bubble.position.y < -bubble.radius { bubble.position.y = bounds.height + bubble.radius }
+            if bubble.position.y > bounds.height + bubble.radius { bubble.position.y = -bubble.radius }
+
+            updated[index] = bubble
+        }
+        DispatchQueue.main.async {
+            self.bubbles = updated
+        }
+    }
+
+    private func makeBubble(for activity: Activity) -> Bubble {
+        let size = bounds
+        let position = CGPoint(x: CGFloat.random(in: 0...max(1, size.width)),
+                               y: CGFloat.random(in: 0...max(1, size.height)))
+        let velocity = CGVector(dx: CGFloat.random(in: -20...20), dy: CGFloat.random(in: -20...20))
+        let radius = CGFloat.random(in: 12...20)
+        return Bubble(activityName: activity.name, colorHex: activity.colorHex, position: position, velocity: velocity, radius: radius)
+    }
+
+    private func rebuildWeights(using activities: [Activity], running: Session?) {
+        var cumulative: Double = 0
+        weightedActivities = activities.map { activity in
+            var weight = Double(max(activity.totalSeconds, 0))
+            if let running,
+               running.activityName.caseInsensitiveCompare(activity.name) == .orderedSame {
+                weight += Double(max(running.durationSeconds, 0))
+            }
+            weight = max(weight, 60)
+            cumulative += weight
+            return (activity, cumulative)
+        }
+        totalWeight = cumulative
+    }
+
+    private func pickWeightedActivity(fallbackPool: [Activity]) -> Activity? {
+        guard totalWeight > 0 else { return fallbackPool.randomElement() }
+        let value = Double.random(in: 0..<totalWeight)
+        if let match = weightedActivities.first(where: { value < $0.cumulativeWeight }) {
+            return match.activity
+        }
+        return weightedActivities.last?.activity ?? fallbackPool.randomElement()
+    }
+}

--- a/Features/Bubbles/BubblesCanvas.swift
+++ b/Features/Bubbles/BubblesCanvas.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+struct BubblesCanvas: View {
+    @EnvironmentObject private var app: AppState
+    @StateObject private var physics = BubblePhysics()
+    @State private var tooltip: Tooltip?
+
+    struct Tooltip: Identifiable {
+        let id = UUID()
+        let activityName: String
+        let colorHex: String
+        let position: CGPoint
+        let totalMinutes: Int
+    }
+
+    var body: some View {
+        GeometryReader { _ in
+            Canvas { context, size in
+                physics.configure(bounds: size, activities: app.availableActivities, running: app.runningSession)
+                for bubble in physics.bubbles {
+                    guard let color = Color(hex: bubble.colorHex) else { continue }
+                    var circle = Path(ellipseIn: CGRect(x: bubble.position.x - bubble.radius,
+                                                        y: bubble.position.y - bubble.radius,
+                                                        width: bubble.radius * 2,
+                                                        height: bubble.radius * 2))
+                    let isRunning = bubble.activityName.caseInsensitiveCompare(app.runningSession?.activityName ?? "") == .orderedSame
+                    let alpha: Double = isRunning ? 0.85 : 0.45
+                    context.fill(circle, with: .color(color.opacity(alpha)))
+                }
+            }
+            .gesture(DragGesture(minimumDistance: 0).onEnded { value in
+                let point = value.location
+                if let bubble = physics.bubbles.first(where: { bubble in
+                    let dx = bubble.position.x - point.x
+                    let dy = bubble.position.y - point.y
+                    return sqrt(dx * dx + dy * dy) <= bubble.radius
+                }) {
+                    let totalSeconds = app.totalSeconds(for: bubble.activityName)
+                    let minutes = max(1, Int(round(Double(totalSeconds) / 60.0)))
+                    tooltip = Tooltip(activityName: bubble.activityName.isEmpty ? "미분류" : bubble.activityName,
+                                      colorHex: bubble.colorHex,
+                                      position: point,
+                                      totalMinutes: minutes)
+                } else {
+                    tooltip = nil
+                }
+            })
+            .onDisappear {
+                physics.tearDown()
+            }
+            .overlay(alignment: .topLeading) {
+                if let tooltip {
+                    BubbleTooltip(tooltip: tooltip)
+                        .position(tooltip.position)
+                        .transition(.opacity.combined(with: .scale))
+                }
+            }
+        }
+    }
+}
+
+private struct BubbleTooltip: View {
+    let tooltip: BubblesCanvas.Tooltip
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(tooltip.activityName)
+                .font(.headline)
+            Text("총 \(tooltip.totalMinutes)분")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color(.systemBackground).opacity(0.85))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Color(hex: tooltip.colorHex) ?? .accentColor, lineWidth: 1)
+        )
+        .shadow(radius: 8)
+    }
+}

--- a/Features/History/DailyStripeView.swift
+++ b/Features/History/DailyStripeView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct DailyStripeView: View {
+    @EnvironmentObject private var app: AppState
+    private let tileHeight: CGFloat = 16
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(app.dayBuckets) { bucket in
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack(spacing: 2) {
+                            ForEach(bucket.tileSlices) { slice in
+                                RoundedRectangle(cornerRadius: 3, style: .continuous)
+                                    .fill(Color(hex: slice.colorHex) ?? .gray)
+                                    .frame(width: max(6, CGFloat(slice.seconds) / 60.0 * 6), height: tileHeight)
+                                    .accessibilityLabel("\(slice.activityName) \(slice.seconds / 60)분")
+                            }
+                        }
+                        Text(bucket.id)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 6)
+        }
+        .background(Color(.systemGray6).opacity(0.7))
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+}
+
+struct DailyStripeView_Previews: PreviewProvider {
+    static var previews: some View {
+        DailyStripeView()
+            .environmentObject(AppState(store: Store()))
+            .frame(height: 40)
+    }
+}

--- a/Features/History/DayCompositor.swift
+++ b/Features/History/DayCompositor.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct DayCompositor {
+    let calendar: Calendar
+
+    init(calendar: Calendar = .current) {
+        self.calendar = calendar
+    }
+
+    func compose(from sessions: [Session], activities: [Activity]) -> [DayBucket] {
+        var buckets: [String: DayBucket] = [:]
+        for session in sessions {
+            guard let activity = activities.first(where: { $0.name.caseInsensitiveCompare(session.activityName) == .orderedSame }) else { continue }
+            var bucket = buckets[session.dayKey] ?? DayBucket(id: session.dayKey)
+            bucket.append(seconds: session.durationSeconds, for: activity)
+            buckets[session.dayKey] = bucket
+        }
+        return buckets.values.sorted { $0.id < $1.id }
+    }
+}

--- a/Features/Logging/LoggingView.swift
+++ b/Features/Logging/LoggingView.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+struct LoggingView: View {
+    @EnvironmentObject private var app: AppState
+    @State private var now: Date = Date()
+    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        ZStack {
+            BubblesCanvas()
+            VStack {
+                Spacer(minLength: 16)
+                if case let .running(since) = app.state {
+                    Text(elapsedString(from: since, to: now))
+                        .font(.system(size: 32, weight: .semibold, design: .rounded))
+                        .monospacedDigit()
+                        .foregroundStyle(.primary)
+                        .padding(.bottom, 24)
+                        .accessibilityLabel("Elapsed time")
+                } else {
+                    Spacer().frame(height: 60)
+                }
+                StartStopButton()
+                    .frame(width: 220, height: 220)
+                    .padding(.vertical, 32)
+                Spacer()
+                DailyStripeView()
+                    .frame(height: 20)
+                    .padding(.bottom, 24)
+            }
+            .padding()
+        }
+        .background(Color(.systemBackground).ignoresSafeArea())
+        .onReceive(timer) { value in
+            now = value
+        }
+        .sheet(isPresented: $app.isPromptPresented) {
+            NamePromptSheet()
+                .environmentObject(app)
+        }
+        .onAppear {
+            app.resumeIfNeeded()
+        }
+    }
+
+    private func elapsedString(from start: Date, to end: Date) -> String {
+        let elapsed = Int(end.timeIntervalSince(start))
+        let hours = elapsed / 3600
+        let minutes = (elapsed % 3600) / 60
+        let seconds = elapsed % 60
+        if hours > 0 {
+            return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+        } else {
+            return String(format: "%02d:%02d", minutes, seconds)
+        }
+    }
+}
+
+struct LoggingView_Previews: PreviewProvider {
+    static var previews: some View {
+        LoggingView()
+            .environmentObject(AppState(store: Store()))
+    }
+}

--- a/Features/Logging/NamePromptSheet.swift
+++ b/Features/Logging/NamePromptSheet.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct NamePromptSheet: View {
+    @EnvironmentObject private var app: AppState
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        NavigationView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("무슨 일을 했는지 입력하세요")
+                    .font(.headline)
+                TextField("업무명", text: $app.promptText, onCommit: commit)
+                    .textFieldStyle(.roundedBorder)
+                    .focused($isFocused)
+                    .submitLabel(.done)
+                if !app.availableActivities.isEmpty {
+                    Text("이전 활동")
+                        .font(.subheadline)
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 12) {
+                            ForEach(app.availableActivities) { activity in
+                                Button {
+                                    app.selectExistingActivity(activity)
+                                } label: {
+                                    Text(activity.name)
+                                        .padding(.horizontal, 12)
+                                        .padding(.vertical, 8)
+                                        .background(Capsule().fill(Color(hex: activity.colorHex) ?? .gray.opacity(0.2)))
+                                        .foregroundStyle(.primary)
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                    }
+                }
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("활동 이름")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("입력", action: commit)
+                        .disabled(app.promptText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+        }
+        .interactiveDismissDisabled(true)
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                isFocused = true
+            }
+        }
+    }
+
+    private func commit() {
+        app.confirmActivityName(app.promptText)
+    }
+}
+
+struct NamePromptSheet_Previews: PreviewProvider {
+    static var previews: some View {
+        NamePromptSheet()
+            .environmentObject(AppState(store: Store()))
+    }
+}

--- a/Features/Logging/StartStopButton.swift
+++ b/Features/Logging/StartStopButton.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+struct StartStopButton: View {
+    @EnvironmentObject private var app: AppState
+    @Environment(\.colorScheme) private var colorScheme
+
+    private enum FeedbackStyle {
+        case light
+        case medium
+    }
+
+    private var isRunning: Bool {
+        if case .running = app.state { return true }
+        return false
+    }
+
+    var body: some View {
+        Button(action: action) {
+            ZStack {
+                Circle()
+                    .fill(isRunning ? Color.red.opacity(0.85) : Color.accentColor)
+                    .overlay(
+                        Circle()
+                            .strokeBorder(Color.white.opacity(colorScheme == .dark ? 0.4 : 0.2), lineWidth: 6)
+                    )
+                    .shadow(color: .black.opacity(0.15), radius: 12, x: 0, y: 8)
+                Text(isRunning ? "Stop" : "Start")
+                    .font(.system(size: 44, weight: .bold, design: .rounded))
+                    .foregroundStyle(Color.white)
+                    .accessibilityLabel(isRunning ? "Stop logging" : "Start logging")
+            }
+        }
+        .buttonStyle(.plain)
+        .contentShape(Circle())
+        .scaleEffect(isRunning ? 0.95 : 1.0)
+        .animation(.spring(response: 0.4, dampingFraction: 0.6), value: isRunning)
+        .simultaneousGesture(LongPressGesture(minimumDuration: 0.2).onEnded { _ in
+            provideHaptic(style: .light)
+        })
+    }
+
+    private func action() {
+        provideHaptic(style: .medium)
+        if isRunning {
+            app.stopLogging()
+        } else {
+            let lastActivity = app.availableActivities.sortedByRecent().first
+            app.startLogging(activityName: lastActivity?.name)
+        }
+    }
+
+    private func provideHaptic(style: FeedbackStyle) {
+        #if canImport(UIKit)
+        let generatorStyle: UIImpactFeedbackGenerator.FeedbackStyle = {
+            switch style {
+            case .light: return .light
+            case .medium: return .medium
+            }
+        }()
+        UIImpactFeedbackGenerator(style: generatorStyle).impactOccurred()
+        #endif
+    }
+}
+
+struct StartStopButton_Previews: PreviewProvider {
+    static var previews: some View {
+        StartStopButton()
+            .environmentObject(AppState(store: Store()))
+            .frame(width: 200, height: 200)
+    }
+}

--- a/Models/Activity.swift
+++ b/Models/Activity.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+struct Activity: Identifiable, Hashable, Codable {
+    var id: UUID
+    var name: String
+    var colorHex: String
+    var totalSeconds: Int
+    var lastUsedAt: Date?
+
+    init(id: UUID = UUID(), name: String, colorHex: String, totalSeconds: Int = 0, lastUsedAt: Date? = nil) {
+        self.id = id
+        self.name = name
+        self.colorHex = colorHex
+        self.totalSeconds = totalSeconds
+        self.lastUsedAt = lastUsedAt
+    }
+
+    var displayName: String { name }
+
+    func adding(seconds: Int) -> Activity {
+        Activity(id: id,
+                 name: name,
+                 colorHex: colorHex,
+                 totalSeconds: totalSeconds + seconds,
+                 lastUsedAt: Date())
+    }
+}
+
+extension Array where Element == Activity {
+    func sortedByRecent() -> [Activity] {
+        sorted { lhs, rhs in
+            switch (lhs.lastUsedAt, rhs.lastUsedAt) {
+            case let (l?, r?):
+                return l > r
+            case (_?, nil):
+                return true
+            case (nil, _?):
+                return false
+            default:
+                return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+        }
+    }
+}

--- a/Models/ColorHash.swift
+++ b/Models/ColorHash.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+func colorHex(for name: String) -> String {
+    let cleaned = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    guard !cleaned.isEmpty else { return "#888888" }
+    let hash = cleaned.utf8.reduce(5381) { ($0 << 5) &+ $0 &+ Int($1) }
+    let hue = Double(abs(hash % 360)) / 360.0
+    let saturation = 0.55
+    let lightness = 0.55
+    let rgb = hslToRGB(hue: hue, saturation: saturation, lightness: lightness)
+    return String(format: "#%02X%02X%02X", Int(rgb.r * 255), Int(rgb.g * 255), Int(rgb.b * 255))
+}
+
+private func hslToRGB(hue: Double, saturation: Double, lightness: Double) -> (r: Double, g: Double, b: Double) {
+    let q: Double
+    if lightness < 0.5 {
+        q = lightness * (1 + saturation)
+    } else {
+        q = lightness + saturation - lightness * saturation
+    }
+    let p = 2 * lightness - q
+
+    func convert(_ t: Double) -> Double {
+        var t = t
+        if t < 0 { t += 1 }
+        if t > 1 { t -= 1 }
+        switch t {
+        case ..<1.0 / 6.0:
+            return p + (q - p) * 6.0 * t
+        case ..<1.0 / 2.0:
+            return q
+        case ..<2.0 / 3.0:
+            return p + (q - p) * (2.0 / 3.0 - t) * 6.0
+        default:
+            return p
+        }
+    }
+
+    let r = convert(hue + 1.0 / 3.0)
+    let g = convert(hue)
+    let b = convert(hue - 1.0 / 3.0)
+    return (max(0, min(1, r)), max(0, min(1, g)), max(0, min(1, b)))
+}
+
+extension Color {
+    init?(hex: String) {
+        var hexSanitized = hex
+        if hexSanitized.hasPrefix("#") {
+            hexSanitized.removeFirst()
+        }
+        guard hexSanitized.count == 6,
+              let intCode = Int(hexSanitized, radix: 16) else { return nil }
+        let r = Double((intCode >> 16) & 0xFF) / 255.0
+        let g = Double((intCode >> 8) & 0xFF) / 255.0
+        let b = Double(intCode & 0xFF) / 255.0
+        self.init(red: r, green: g, blue: b)
+    }
+}

--- a/Models/DayBucket.swift
+++ b/Models/DayBucket.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+struct TileSlice: Identifiable, Hashable, Codable {
+    var id: UUID
+    var activityName: String
+    var colorHex: String
+    var seconds: Int
+
+    init(id: UUID = UUID(), activityName: String, colorHex: String, seconds: Int) {
+        self.id = id
+        self.activityName = activityName
+        self.colorHex = colorHex
+        self.seconds = seconds
+    }
+}
+
+struct DayBucket: Identifiable, Codable {
+    var id: String
+    var tileSlices: [TileSlice]
+
+    init(id: String, tileSlices: [TileSlice] = []) {
+        self.id = id
+        self.tileSlices = tileSlices
+    }
+
+    mutating func append(seconds: Int, for activity: Activity) {
+        guard seconds > 0 else { return }
+        if var last = tileSlices.last, last.activityName.caseInsensitiveCompare(activity.name) == .orderedSame {
+            last.seconds += seconds
+            tileSlices.removeLast()
+            tileSlices.append(last)
+        } else {
+            let slice = TileSlice(activityName: activity.name, colorHex: activity.colorHex, seconds: seconds)
+            tileSlices.append(slice)
+        }
+    }
+}
+
+extension Array where Element == DayBucket {
+    func bucket(for dayKey: String) -> DayBucket? {
+        first { $0.id == dayKey }
+    }
+}

--- a/Models/Session.swift
+++ b/Models/Session.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+struct Session: Identifiable, Codable {
+    var id: UUID
+    var activityName: String
+    var start: Date
+    var end: Date?
+    var dayKey: String
+
+    init(id: UUID = UUID(), activityName: String, start: Date = Date(), end: Date? = nil, dayKey: String? = nil) {
+        self.id = id
+        self.activityName = activityName
+        self.start = start
+        self.end = end
+        self.dayKey = dayKey ?? Self.makeDayKey(from: start)
+    }
+
+    var durationSeconds: Int {
+        max(0, Int((end ?? Date()).timeIntervalSince(start)))
+    }
+
+    var isRunning: Bool { end == nil }
+
+    mutating func close(at endDate: Date) {
+        guard end == nil else { return }
+        end = endDate
+    }
+
+    static func makeDayKey(from date: Date, calendar: Calendar = .current) -> String {
+        let comps = calendar.dateComponents([.year, .month, .day], from: date)
+        return String(format: "%04d-%02d-%02d", comps.year ?? 0, comps.month ?? 0, comps.day ?? 0)
+    }
+}

--- a/Persistence/Store.swift
+++ b/Persistence/Store.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+@MainActor
+final class Store: ObservableObject {
+    private let persistenceQueue = DispatchQueue(label: "StorePersistenceQueue", qos: .utility)
+    private let url: URL
+
+    @Published private(set) var activities: [Activity]
+    @Published private(set) var sessions: [Session]
+    @Published private(set) var dayBuckets: [DayBucket]
+    @Published private(set) var runningSession: Session?
+
+    struct Snapshot: Codable {
+        var activities: [Activity]
+        var sessions: [Session]
+        var dayBuckets: [DayBucket]
+        var runningSession: Session?
+    }
+
+    init(filename: String = "store.json") {
+        let documentURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
+        url = documentURL.appendingPathComponent(filename)
+
+        if let data = try? Data(contentsOf: url),
+           let snapshot = try? JSONDecoder().decode(Snapshot.self, from: data) {
+            activities = snapshot.activities
+            sessions = snapshot.sessions
+            dayBuckets = snapshot.dayBuckets
+            runningSession = snapshot.runningSession
+        } else {
+            activities = []
+            sessions = []
+            dayBuckets = []
+            runningSession = nil
+        }
+    }
+
+    func startSession(named activityName: String?) {
+        guard runningSession == nil else { return }
+        let trimmed = activityName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        var session = Session(activityName: trimmed, start: Date())
+        if trimmed.isEmpty {
+            session.activityName = ""
+        } else {
+            touchActivity(named: trimmed)
+        }
+        runningSession = session
+        persist()
+    }
+
+    func stopSession(at endDate: Date = Date()) {
+        guard var session = runningSession else { return }
+        session.close(at: endDate)
+        runningSession = session
+        persist()
+    }
+
+    func finalizeSession(activityName: String) {
+        let normalizedName = activityName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedName.isEmpty else { return }
+        guard var session = runningSession else { return }
+
+        session.activityName = normalizedName
+        if session.end == nil {
+            session.close(at: Date())
+        }
+
+        let duration = session.durationSeconds
+        let hex = colorHex(for: normalizedName)
+
+        var updatedActivities = activities
+        if let index = updatedActivities.firstIndex(where: { $0.name.caseInsensitiveCompare(normalizedName) == .orderedSame }) {
+            updatedActivities[index] = updatedActivities[index].adding(seconds: duration)
+        } else {
+            let activity = Activity(name: normalizedName,
+                                    colorHex: hex,
+                                    totalSeconds: duration,
+                                    lastUsedAt: Date())
+            updatedActivities.append(activity)
+        }
+
+        var updatedSessions = sessions
+        updatedSessions.append(session)
+
+        var updatedBuckets = dayBuckets
+        if let bucketIndex = updatedBuckets.firstIndex(where: { $0.id == session.dayKey }) {
+            var bucket = updatedBuckets[bucketIndex]
+            let activity = updatedActivities.first { $0.name.caseInsensitiveCompare(normalizedName) == .orderedSame }
+                ?? Activity(name: normalizedName, colorHex: hex, totalSeconds: duration)
+            bucket.append(seconds: duration, for: activity)
+            updatedBuckets[bucketIndex] = bucket
+        } else {
+            let activity = updatedActivities.first { $0.name.caseInsensitiveCompare(normalizedName) == .orderedSame }
+                ?? Activity(name: normalizedName, colorHex: hex, totalSeconds: duration)
+            var bucket = DayBucket(id: session.dayKey)
+            bucket.append(seconds: duration, for: activity)
+            updatedBuckets.append(bucket)
+            updatedBuckets.sort { $0.id < $1.id }
+        }
+
+        activities = updatedActivities
+        sessions = updatedSessions
+        dayBuckets = updatedBuckets
+        runningSession = nil
+
+        persist()
+    }
+
+    func touchActivity(named name: String) {
+        guard let index = activities.firstIndex(where: { $0.name.caseInsensitiveCompare(name) == .orderedSame }) else { return }
+        activities[index].lastUsedAt = Date()
+    }
+
+    func totalSeconds(for activityName: String) -> Int {
+        let base = activities.first(where: { $0.name.caseInsensitiveCompare(activityName) == .orderedSame })?.totalSeconds ?? 0
+        if let running = runningSession,
+           running.activityName.caseInsensitiveCompare(activityName) == .orderedSame {
+            return base + running.durationSeconds
+        }
+        return base
+    }
+
+    func todaySlices(calendar: Calendar = .current) -> [TileSlice] {
+        let key = Session.makeDayKey(from: Date(), calendar: calendar)
+        return dayBuckets.first(where: { $0.id == key })?.tileSlices ?? []
+    }
+
+    private func persist() {
+        let snapshot = Snapshot(activities: activities,
+                                sessions: sessions,
+                                dayBuckets: dayBuckets,
+                                runningSession: runningSession)
+        let url = self.url
+        persistenceQueue.async {
+            guard let data = try? JSONEncoder().encode(snapshot) else { return }
+            try? data.write(to: url, options: .atomic)
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # neolog
+
+Minimal SwiftUI app to log what you are currently doing. Tap the central button to start or stop logging, name the activity, and watch deterministic-color bubbles float based on your history. A daily stripe timeline at the bottom visualizes how your time accumulates day by day. All information is persisted locally on device via a lightweight JSON store.


### PR DESCRIPTION
## Summary
- bias bubble spawning toward activities with more logged time and prune bubbles for removed activities
- scale the bubble population using logged minutes so history-rich days surface more ambient motion without breaking the cap

## Testing
- not run (iOS build tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d82df8ed98832aa136a5a39e7c4d67